### PR TITLE
Speed up the DHT bootstrapping

### DIFF
--- a/torrent2http.go
+++ b/torrent2http.go
@@ -132,6 +132,13 @@ func startServices() {
     log.Println("Starting DHT...")
     instance.session.Start_dht()
 
+    // add some *known* dht routers to speed up dht bootstrapping
+    instance.session.Add_dht_router(libtorrent.NewPair_str_int("router.bittorrent.com", 6881))
+    instance.session.Add_dht_router(libtorrent.NewPair_str_int("router.utorrent.com", 6881))
+    instance.session.Add_dht_router(libtorrent.NewPair_str_int("dht.transmissionbt.com", 6881))
+    instance.session.Add_dht_router(libtorrent.NewPair_str_int("dht.aelitis.com", 6881))
+
+
     log.Println("Starting LSD...")
     instance.session.Start_lsd()
 


### PR DESCRIPTION
This patch add some DHT routers during DHT initialization, like many popular bittorrent clients do in order to speed up the dht bootstrapping process.

This should solve steeve/xbmctorrent#138.

Note that this requires steeve/libtorrent-go#2.
